### PR TITLE
Added DateRangeFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateRangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateRangeFieldMapper.java
@@ -1,0 +1,67 @@
+public class DateRangeFieldMapper extends FieldMapper {
+
+    private final DateFieldMapper startFieldMapper;
+    private final DateFieldMapper endFieldMapper;
+
+    public DateRangeFieldMapper(String simpleName, MappedFieldType mappedFieldType, MultiFields multiFields, CopyTo copyTo,
+                                DateFieldMapper startFieldMapper, DateFieldMapper endFieldMapper) {
+        super(simpleName, mappedFieldType, multiFields, copyTo);
+        this.startFieldMapper = startFieldMapper;
+        this.endFieldMapper = endFieldMapper;
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context) throws IOException {
+        XContentParser parser = context.parser();
+        XContentParser.Token token = parser.currentToken();
+
+        if (token.equals(XContentParser.Token.START_OBJECT)) {
+            String currentFieldName = null;
+            Instant startDate = null;
+            Instant endDate = null;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (currentFieldName != null) {
+                    if (currentFieldName.equals("start")) {
+                        startDate = Instant.parse(parser.text());
+                    } else if (currentFieldName.equals("end")) {
+                        endDate = Instant.parse(parser.text());
+                    }
+                }
+            }
+            if (startDate != null && endDate != null) {
+                Range range = new Range(startDate, endDate);
+                context.doc().add(new Field(fieldType().name(), range.toString(), fieldType()));
+            }
+        } else {
+            throw new IllegalArgumentException("Expected START_OBJECT but got " + token);
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        boolean includeInAll = params.paramAsBoolean("include_in_all", false);
+
+        builder.startObject("start");
+        builder.field("type", startFieldMapper.contentType());
+        if (includeInAll) {
+            builder.field("include_in_all", true);
+        }
+        builder.field("format", startFieldMapper.dateTimeFormatter().pattern());
+        builder.endObject();
+
+        builder.startObject("end");
+        builder.field("type", endFieldMapper.contentType());
+        if (includeInAll) {
+            builder.field("include_in_all", true);
+        }
+        builder.field("format", endFieldMapper.dateTimeFormatter().pattern());
+        builder.endObject();
+    }
+
+    @Override
+    protected String contentType() {
+        return "date_range";
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

Issue: https://github.com/elastic/elasticsearch/issues/89707

This adds `DateRangeFieldMapper` to use as a `FieldMapper` instead of `DateFieldMapper` within `runtime_fields`. `DateRangeFieldMapper` holds two instances of `DateFieldMapper` to serve as the start and end of the date range. The implementation of `DateRangeFieldMapper` is a much bigger task and should be split into more issues to implement this change in various modules.


- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
